### PR TITLE
Use priv key hash as identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ $ cargo run --release -- --msg "messsage to sign" --receipt-file receipt.bin --u
 ```
 
 ## Benchmarks, Apple M1 Max
-- Proving time is about 5:50 minutes (not counting loading the UTXO set into
+- Proving time is about 6:57 minutes (not counting loading the UTXO set into
   memory).
-- Verification time is ~250 ms.
-- Proof size is 1.4 MB.
+- Verification time is ~300 ms.
+- Proof size is 1.7 MB.
 
 ## Limitations
 This is a rough first draft of how a tool like this could look like. It has

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -7,23 +7,26 @@ use rustreexo::accumulator::stump::Stump;
 use sha2::{Digest, Sha512_256};
 
 use bitcoin::XOnlyPublicKey;
+use bitcoin::key::Keypair;
 use bitcoin::consensus::encode::serialize;
-use bitcoin::secp256k1::{Secp256k1, Scalar};
+use bitcoin::secp256k1::{Secp256k1, Scalar, SecretKey};
 use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::{ScriptBuf, TxOut, Amount};
 
 fn main() {
-    let secp = Secp256k1::verification_only();
+    let secp = Secp256k1::new();
 
     // read the input
+    let priv_key: SecretKey = env::read();
     let s: Stump = env::read();
     let proof: Proof = env::read();
-    let internal_key: XOnlyPublicKey = env::read();
     let blinding_bytes: [u8; 32] = env::read();
     let signature: Signature = env::read();
 
+    let keypair = Keypair::from_secret_key(&secp, &priv_key);
+    let (internal_key, _) = keypair.x_only_public_key();
+
     // We'll check that the given public key corresponds to an output in the utxo set.
-    let mut hasher = Sha512_256::new();
     let script_pubkey = ScriptBuf::new_p2tr(&secp, internal_key, None);
     let utxo = TxOut {
         value: Amount::ZERO,
@@ -31,12 +34,18 @@ fn main() {
     };
 
     let serialized_txout = serialize(&utxo);
+
+    let mut hasher = Sha512_256::new();
     hasher.update(&serialized_txout);
     let result = hasher.finalize();
     let myhash = NodeHash::from_str(hex::encode(result).as_str()).unwrap();
 
     // Assert it is in the set.
     assert_eq!(s.verify(&proof, &[myhash]), Ok(true));
+
+    let mut hasher = Sha512_256::new();
+    hasher.update(&priv_key.secret_bytes());
+    let sk_hash = hex::encode(hasher.finalize());
 
     // Blind the public key before commiting it to the public inputs.
     let blinding_scalar = Scalar::from_be_bytes(blinding_bytes).unwrap();
@@ -46,4 +55,5 @@ fn main() {
     env::commit(&s);
     env::commit(&signature);
     env::commit(&blinded_pubkey);
+    env::commit(&sk_hash);
 }


### PR DESCRIPTION
Instead of supplying the public key to the ZKVM, we pass the private key. We then commit the hash of the private key to the public journal, making it possible to check whether a UTXO has been used in a different proof.