### PR TITLE
utreexo accumulator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["host", "methods"]
+members = ["host", "methods", "shared"]
 
 # Always optimize; building and running the guest takes much longer without optimization.
 [profile.dev]

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2021"
 
 [dependencies]
 methods = { path = "../methods" }
+shared = { path = "../shared" }
 risc0-zkvm = { version = "1.0.5" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"
 rustreexo = { version = "0.3.0", features = ["with-serde"] }
-bitcoin = { version = "0.31.2", features = ["std", "rand-std", "serde"] }
+bitcoin = { version = "0.32.5", features = ["std", "rand-std", "serde"] }
 bincode = "1.3.3"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 clap = { version = "4.5.16", features = ["derive"] }

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -13,7 +13,7 @@ bitcoin = { version = "0.31.2", features = ["std", "rand-std", "serde"] }
 bincode = "1.3.3"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 clap = { version = "4.5.16", features = ["derive"] }
-txoutset = "0.3.0"
 sha2 = "0.10.8"
 bitcoin_hashes = "0.14.0"
 k256 = { version = "0.13.3", features = ["serde"] }
+serde_json = "1.0.128"

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -239,8 +239,6 @@ fn main() {
         .unwrap()
         .write(&priv_key)
         .unwrap()
-        .write(&leaf_hash)
-        .unwrap()
         .write(&acc)
         .unwrap()
         .write(&proof)

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -4,9 +4,6 @@ use std::fs::File;
 use methods::{METHOD_ELF, METHOD_ID};
 use risc0_zkvm::{default_prover, ExecutorEnv, Receipt};
 
-use sha2::{Digest};
-use std::io::Write;
-
 use bitcoin_hashes::sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
 

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -245,6 +245,14 @@ fn main() {
         .unwrap()
         .write(&sig_bytes.as_slice())
         .unwrap()
+        .write(&tx)
+        .unwrap()
+        .write(&vout)
+        .unwrap()
+        .write(&block_height)
+        .unwrap()
+        .write(&block_hash)
+        .unwrap()
         .build()
         .unwrap();
 

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -198,6 +198,8 @@ fn main() {
     let priv_key = schnorr::SigningKey::from_bytes(&priv_bytes).unwrap();
     let script_pubkey = ScriptBuf::new_p2tr(&secp, internal_key, None);
 
+    assert_eq!(tx.output[vout as usize].script_pubkey, script_pubkey);
+
     println!("proving {}", leaf_hash);
     println!("proof: {:?}", proof);
     assert_eq!(acc.verify(&proof, &[leaf_hash]), Ok(true));

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -17,12 +17,10 @@ use rustreexo::accumulator::stump::Stump;
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use bitcoin::address::Payload;
-use bitcoin::consensus::encode::serialize;
 use bitcoin::consensus::{deserialize, Encodable};
 use bitcoin::key::Keypair;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
-use bitcoin::{Address, Amount, BlockHash, Network, ScriptBuf, Transaction, TxOut};
+use bitcoin::{Address, BlockHash, Network, ScriptBuf, Transaction};
 use k256::schnorr;
 use k256::schnorr::signature::Verifier;
 use rustreexo::accumulator::proof::Proof;
@@ -89,25 +87,6 @@ struct CliProof {
 struct CliStump {
     pub roots: Vec<String>,
     pub leaves: u64,
-}
-
-fn create_nodehash(script_buf: ScriptBuf) -> NodeHash {
-    // Simple node hash representation: hash the script pubkey. In a real application one would use
-    // the regular utreexo serialization, which contains more info about the UTXO.
-    let txout = TxOut {
-        value: Amount::ZERO,
-        script_pubkey: script_buf,
-    };
-
-    // Serialize the TxOut using bitcoin::consensus::encode::serialize
-    let serialized_txout = serialize(&txout);
-    let mut hasher = Sha512_256::new();
-    hasher.update(&serialized_txout);
-
-    let result = hasher.finalize();
-    let hash = NodeHash::from_str(hex::encode(result).as_str()).unwrap();
-
-    hash
 }
 
 fn main() {
@@ -257,6 +236,8 @@ fn main() {
         .write(&msg_bytes)
         .unwrap()
         .write(&priv_key)
+        .unwrap()
+        .write(&leaf_hash)
         .unwrap()
         .write(&acc)
         .unwrap()

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -13,6 +13,7 @@ bitcoin = { version = "0.32.2", features = ["serde"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 sha2 = "0.10.8"
 k256 = { version = "=0.13.3", features = ["arithmetic", "serde", "expose-field", "std", "ecdsa", "pkcs8", "schnorr"], default-features = false }
+bitcoin_hashes = "0.14.0"
 
 [patch.crates-io]
 # Placing these patch statement in the workspace Cargo.toml will add RISC Zero SHA-256 and bigint

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 [workspace]
 
 [dependencies]
+shared = { path = "../../shared" }
 risc0-zkvm = { version = "1.0.5", default-features = false, features = ['std'] }
 rustreexo = { version = "0.3.0", features = ["with-serde"] }
 serde = "1.0"
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin = { version = "0.32.5", features = ["serde"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 sha2 = "0.10.8"
 k256 = { version = "=0.13.3", features = ["arithmetic", "serde", "expose-field", "std", "ecdsa", "pkcs8", "schnorr"], default-features = false }

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -84,10 +84,9 @@ fn main() {
     // We'll check that the given public key corresponds to an output in the utxo set.
     let pubx = XOnlyPublicKey::from_slice(internal_key.to_bytes().as_slice()).unwrap();
     let script_pubkey = new_p2tr(pubx, None);
-    let utxo = TxOut {
-        value: Amount::ZERO,
-        script_pubkey,
-    };
+
+    // assert internal key is in tx used to calc leaf hash
+    assert_eq!(tx.output[vout as usize].script_pubkey, script_pubkey);
 
     // Assert it is in the set.
     assert_eq!(s.verify(&proof, &[leaf_hash]), Ok(true));

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -16,6 +16,8 @@ use k256::schnorr;
 use k256::schnorr::signature::Verifier;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 
+use shared::get_leaf_hashes;
+
 pub fn new_p2tr(
     internal_key: UntweakedPublicKey,
     merkle_root: Option<TapNodeHash>,
@@ -104,42 +106,4 @@ fn main() {
     env::commit(&s);
     env::commit(&sk_hash);
     env::commit(&msg);
-}
-
-pub const UTREEXO_TAG_V1: [u8; 64] = [
-    0x5b, 0x83, 0x2d, 0xb8, 0xca, 0x26, 0xc2, 0x5b, 0xe1, 0xc5, 0x42, 0xd6, 0xcc, 0xed, 0xdd, 0xa8,
-    0xc1, 0x45, 0x61, 0x5c, 0xff, 0x5c, 0x35, 0x72, 0x7f, 0xb3, 0x46, 0x26, 0x10, 0x80, 0x7e, 0x20,
-    0xae, 0x53, 0x4d, 0xc3, 0xf6, 0x42, 0x99, 0x19, 0x99, 0x31, 0x77, 0x2e, 0x03, 0x78, 0x7d, 0x18,
-    0x15, 0x6e, 0xb3, 0x15, 0x1e, 0x0e, 0xd1, 0xb3, 0x09, 0x8b, 0xdc, 0x84, 0x45, 0x86, 0x18, 0x85,
-];
-
-fn get_leaf_hashes(
-    transaction: &Transaction,
-    vout: u32,
-    height: u32,
-    block_hash: BlockHash,
-) -> sha256::Hash {
-    let header_code = height << 1;
-
-    let mut ser_utxo = Vec::new();
-    let utxo = transaction.output.get(vout as usize).unwrap();
-    utxo.consensus_encode(&mut ser_utxo).unwrap();
-    let header_code = if transaction.is_coinbase() {
-        header_code | 1
-    } else {
-        header_code
-    };
-    let txid = transaction.txid();
-
-    let leaf_hash = Sha512_256::new()
-        .chain_update(UTREEXO_TAG_V1)
-        .chain_update(UTREEXO_TAG_V1)
-        .chain_update(block_hash)
-        .chain_update(transaction.txid())
-        .chain_update(vout.to_le_bytes())
-        .chain_update(header_code.to_le_bytes())
-        .chain_update(ser_utxo)
-        .finalize();
-    sha256::Hash::from_slice(leaf_hash.as_slice())
-        .expect("parent_hash: Engines shouldn't be Err")
 }

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -63,6 +63,7 @@ fn main() {
     // read the input
     let msg_bytes: Vec<u8> = env::read();
     let priv_key: schnorr::SigningKey = env::read();
+    let leaf_hash: NodeHash = env::read();
     let s: Stump = env::read();
     let proof: Proof = env::read();
     let sig_bytes: Vec<u8> = env::read();
@@ -77,15 +78,8 @@ fn main() {
         script_pubkey,
     };
 
-    let serialized_txout = serialize(&utxo);
-
-    let mut hasher = Sha512_256::new();
-    hasher.update(&serialized_txout);
-    let result = hasher.finalize();
-    let myhash = NodeHash::from_str(hex::encode(result).as_str()).unwrap();
-
     // Assert it is in the set.
-    assert_eq!(s.verify(&proof, &[myhash]), Ok(true));
+    assert_eq!(s.verify(&proof, &[leaf_hash]), Ok(true));
 
     let mut hasher = Sha512_256::new();
     hasher.update(&priv_key.to_bytes());

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -65,7 +65,6 @@ fn main() {
     // read the input
     let msg_bytes: Vec<u8> = env::read();
     let priv_key: schnorr::SigningKey = env::read();
-    let leaf_hash: NodeHash = env::read();
     let s: Stump = env::read();
     let proof: Proof = env::read();
     let sig_bytes: Vec<u8> = env::read();
@@ -76,8 +75,7 @@ fn main() {
     let block_hash: BlockHash = env::read();
 
     let lh = get_leaf_hashes(&tx, vout, block_height, block_hash);
-    let lh = NodeHash::from(lh);
-    assert_eq!(lh, leaf_hash);
+    let leaf_hash = NodeHash::from(lh);
 
     let internal_key = priv_key.verifying_key();
 

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -1,4 +1,4 @@
-use std::str::{from_utf8, FromStr};
+use std::str::{from_utf8};
 
 use risc0_zkvm::guest::env;
 use rustreexo::accumulator::node_hash::NodeHash;
@@ -11,8 +11,7 @@ use bitcoin_hashes::Hash;
 use bitcoin::key::{UntweakedPublicKey};
 use bitcoin::{Amount, ScriptBuf, Transaction, BlockHash, TapNodeHash, TapTweakHash, TxOut, WitnessVersion, XOnlyPublicKey};
 use bitcoin::script::{Builder, PushBytes};
-use bitcoin::consensus::encode::serialize;
-use bitcoin::consensus::{deserialize, Encodable};
+use bitcoin::consensus::Encodable;
 use k256::schnorr;
 use k256::schnorr::signature::Verifier;
 use k256::elliptic_curve::sec1::ToEncodedPoint;

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -6,12 +6,9 @@ use rustreexo::accumulator::proof::Proof;
 use rustreexo::accumulator::stump::Stump;
 use sha2::{Digest, Sha512_256};
 
-use bitcoin_hashes::sha256;
-use bitcoin_hashes::Hash;
 use bitcoin::key::{UntweakedPublicKey};
-use bitcoin::{Amount, ScriptBuf, Transaction, BlockHash, TapNodeHash, TapTweakHash, TxOut, WitnessVersion, XOnlyPublicKey};
+use bitcoin::{ScriptBuf, Transaction, BlockHash, TapNodeHash, TapTweakHash, WitnessVersion, XOnlyPublicKey};
 use bitcoin::script::{Builder, PushBytes};
-use bitcoin::consensus::Encodable;
 use k256::schnorr;
 use k256::schnorr::signature::Verifier;
 use k256::elliptic_curve::sec1::ToEncodedPoint;

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -6,10 +6,13 @@ use rustreexo::accumulator::proof::Proof;
 use rustreexo::accumulator::stump::Stump;
 use sha2::{Digest, Sha512_256};
 
+use bitcoin_hashes::sha256;
+use bitcoin_hashes::Hash;
 use bitcoin::key::{UntweakedPublicKey};
-use bitcoin::{Amount, ScriptBuf, TapNodeHash, TapTweakHash, TxOut, WitnessVersion, XOnlyPublicKey};
+use bitcoin::{Amount, ScriptBuf, Transaction, BlockHash, TapNodeHash, TapTweakHash, TxOut, WitnessVersion, XOnlyPublicKey};
 use bitcoin::script::{Builder, PushBytes};
 use bitcoin::consensus::encode::serialize;
+use bitcoin::consensus::{deserialize, Encodable};
 use k256::schnorr;
 use k256::schnorr::signature::Verifier;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
@@ -68,6 +71,15 @@ fn main() {
     let proof: Proof = env::read();
     let sig_bytes: Vec<u8> = env::read();
 
+    let tx: Transaction = env::read();
+    let vout: u32 = env::read();
+    let block_height: u32 = env::read();
+    let block_hash: BlockHash = env::read();
+
+    let lh = get_leaf_hashes(&tx, vout, block_height, block_hash);
+    let lh = NodeHash::from(lh);
+    assert_eq!(lh, leaf_hash);
+
     let internal_key = priv_key.verifying_key();
 
     // We'll check that the given public key corresponds to an output in the utxo set.
@@ -96,4 +108,42 @@ fn main() {
     env::commit(&s);
     env::commit(&sk_hash);
     env::commit(&msg);
+}
+
+pub const UTREEXO_TAG_V1: [u8; 64] = [
+    0x5b, 0x83, 0x2d, 0xb8, 0xca, 0x26, 0xc2, 0x5b, 0xe1, 0xc5, 0x42, 0xd6, 0xcc, 0xed, 0xdd, 0xa8,
+    0xc1, 0x45, 0x61, 0x5c, 0xff, 0x5c, 0x35, 0x72, 0x7f, 0xb3, 0x46, 0x26, 0x10, 0x80, 0x7e, 0x20,
+    0xae, 0x53, 0x4d, 0xc3, 0xf6, 0x42, 0x99, 0x19, 0x99, 0x31, 0x77, 0x2e, 0x03, 0x78, 0x7d, 0x18,
+    0x15, 0x6e, 0xb3, 0x15, 0x1e, 0x0e, 0xd1, 0xb3, 0x09, 0x8b, 0xdc, 0x84, 0x45, 0x86, 0x18, 0x85,
+];
+
+fn get_leaf_hashes(
+    transaction: &Transaction,
+    vout: u32,
+    height: u32,
+    block_hash: BlockHash,
+) -> sha256::Hash {
+    let header_code = height << 1;
+
+    let mut ser_utxo = Vec::new();
+    let utxo = transaction.output.get(vout as usize).unwrap();
+    utxo.consensus_encode(&mut ser_utxo).unwrap();
+    let header_code = if transaction.is_coinbase() {
+        header_code | 1
+    } else {
+        header_code
+    };
+    let txid = transaction.txid();
+
+    let leaf_hash = Sha512_256::new()
+        .chain_update(UTREEXO_TAG_V1)
+        .chain_update(UTREEXO_TAG_V1)
+        .chain_update(block_hash)
+        .chain_update(transaction.txid())
+        .chain_update(vout.to_le_bytes())
+        .chain_update(header_code.to_le_bytes())
+        .chain_update(ser_utxo)
+        .finalize();
+    sha256::Hash::from_slice(leaf_hash.as_slice())
+        .expect("parent_hash: Engines shouldn't be Err")
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bitcoin = { version = "0.32.5"}
+sha2 = "0.10.8"
+bitcoin_hashes = "0.14.0"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,0 +1,45 @@
+use bitcoin_hashes::sha256;
+use bitcoin_hashes::Hash as BitcoinHash;
+
+use sha2::{Digest, Sha512_256};
+
+use bitcoin::consensus::Encodable;
+use bitcoin::{BlockHash, Transaction};
+
+pub const UTREEXO_TAG_V1: [u8; 64] = [
+    0x5b, 0x83, 0x2d, 0xb8, 0xca, 0x26, 0xc2, 0x5b, 0xe1, 0xc5, 0x42, 0xd6, 0xcc, 0xed, 0xdd, 0xa8,
+    0xc1, 0x45, 0x61, 0x5c, 0xff, 0x5c, 0x35, 0x72, 0x7f, 0xb3, 0x46, 0x26, 0x10, 0x80, 0x7e, 0x20,
+    0xae, 0x53, 0x4d, 0xc3, 0xf6, 0x42, 0x99, 0x19, 0x99, 0x31, 0x77, 0x2e, 0x03, 0x78, 0x7d, 0x18,
+    0x15, 0x6e, 0xb3, 0x15, 0x1e, 0x0e, 0xd1, 0xb3, 0x09, 0x8b, 0xdc, 0x84, 0x45, 0x86, 0x18, 0x85,
+];
+
+pub fn get_leaf_hashes(
+    transaction: &Transaction,
+    vout: u32,
+    height: u32,
+    block_hash: BlockHash,
+) -> sha256::Hash {
+    let header_code = height << 1;
+
+    let mut ser_utxo = Vec::new();
+    let utxo = transaction.output.get(vout as usize).unwrap();
+    utxo.consensus_encode(&mut ser_utxo).unwrap();
+    let header_code = if transaction.is_coinbase() {
+        header_code | 1
+    } else {
+        header_code
+    };
+    let txid = transaction.txid();
+    println!("txid: {txid}, block_hash: {block_hash} vout: {vout} height: {height}");
+
+    let leaf_hash = Sha512_256::new()
+        .chain_update(UTREEXO_TAG_V1)
+        .chain_update(UTREEXO_TAG_V1)
+        .chain_update(block_hash)
+        .chain_update(transaction.txid())
+        .chain_update(vout.to_le_bytes())
+        .chain_update(header_code.to_le_bytes())
+        .chain_update(ser_utxo)
+        .finalize();
+    sha256::Hash::from_slice(leaf_hash.as_slice()).expect("parent_hash: Engines shouldn't be Err")
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -29,14 +29,14 @@ pub fn get_leaf_hashes(
     } else {
         header_code
     };
-    let txid = transaction.txid();
+    let txid = transaction.compute_txid();
     println!("txid: {txid}, block_hash: {block_hash} vout: {vout} height: {height}");
 
     let leaf_hash = Sha512_256::new()
         .chain_update(UTREEXO_TAG_V1)
         .chain_update(UTREEXO_TAG_V1)
         .chain_update(block_hash)
-        .chain_update(transaction.txid())
+        .chain_update(txid)
         .chain_update(vout.to_le_bytes())
         .chain_update(header_code.to_le_bytes())
         .chain_update(ser_utxo)


### PR DESCRIPTION
Instead of creating utreexo accumulator from dumped UTXO set, we take the accumulator as a command line argument.

This lets the prover dump a proofs and accumulator directly from a utreexo node like [rpc-utreexo-bridge](https://github.com/Davidson-Souza/rpc-utreexo-bridge).

TODO:
- [x] update docs to match